### PR TITLE
fix: update Linux download links to v1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 VoiceFlow brings OpenAI's Whisper directly to your machine. Every word you speak is processed entirely on your hardware—your voice data never leaves your device. Built for privacy-conscious professionals who demand speed and reliability.
 
 > **New: Linux Support (Experimental)**
-> VoiceFlow now runs on Linux with Wayland-native input, evdev hotkeys, and AppImage packaging. [Download the Linux release](https://github.com/infiniV/VoiceFlow/releases/tag/v1.4.0-linux-experimental)
+> VoiceFlow now runs on Linux with Wayland-native input, evdev hotkeys, and AppImage packaging. [Download the Linux release](https://github.com/infiniV/VoiceFlow/releases/tag/v1.3.2)
 
 <p align="center">
   <a href="https://github.com/infiniV/VoiceFlow/releases/download/v1.3.1/VoiceFlowSetup-1.3.1.exe">
     <img src="https://img.shields.io/badge/Download_for_Windows-000000?style=for-the-badge&logo=windows&logoColor=white" alt="Download">
   </a>
-  <a href="https://github.com/infiniV/VoiceFlow/releases/tag/v1.4.0-linux-experimental">
+  <a href="https://github.com/infiniV/VoiceFlow/releases/tag/v1.3.2">
     <img src="https://img.shields.io/badge/Download_for_Linux_(Experimental)-000000?style=for-the-badge&logo=linux&logoColor=white" alt="Download Linux">
   </a>
   <a href="https://github.com/infiniV/VoiceFlow">


### PR DESCRIPTION
## Summary
- Both Linux download links in README pointed to the old `v1.4.0-linux-experimental` pre-release
- Updated to point to `v1.3.2` which is the latest Linux release with CUDA and paste fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux download information in README with corrected version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->