### PR TITLE
feat: GitHub Actions CI/CD and Linux audio compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
             libgl1-mesa-dev libegl1-mesa-dev libxkbcommon0 libfontconfig1 \
             libdbus-1-3 libxcb-xinerama0 libxcb-cursor0 libxcb-shape0 \
             libxcb-icccm4 libxcb-keysyms1 libxcb-render-util0 libxcb-image0 \
-            libnss3 libasound2 libfuse2
+            libnss3 libasound2 libfuse2 execstack
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -58,8 +58,8 @@ jobs:
 
       - name: Setup Python environment
         run: |
-          uv python install 3.13
-          uv venv --python 3.13 .venv
+          uv python install 3.12
+          uv venv --python 3.12 .venv
           uv sync
 
       - name: Determine version
@@ -76,6 +76,19 @@ jobs:
 
       - name: Build application
         run: pnpm run build
+
+      - name: Clear executable stack flags
+        run: |
+          # python-build-standalone builds ship libpython with GNU_STACK RWE,
+          # which Linux 6.8+ kernels reject. Clear the flag on all bundled .so files.
+          find ./dist/VoiceFlow -name '*.so*' -exec execstack -c {} +
+          echo "Verifying no executable stacks remain..."
+          BAD=$(find ./dist/VoiceFlow -name '*.so*' -exec sh -c \
+            'readelf -l "$1" 2>/dev/null | grep -A1 GNU_STACK | grep -q RWE && echo "$1"' _ {} \;)
+          if [ -n "$BAD" ]; then
+            echo "::error::Files still have executable stack: $BAD"
+            exit 1
+          fi
 
       - name: Smoke test - check for missing shared libraries
         run: |
@@ -130,8 +143,8 @@ jobs:
 
       - name: Setup Python environment
         run: |
-          uv python install 3.13
-          uv venv --python 3.13 .venv
+          uv python install 3.12
+          uv venv --python 3.12 .venv
           uv sync
 
       - name: Determine version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
             libgl1-mesa-dev libegl1-mesa-dev libxkbcommon0 libfontconfig1 \
             libdbus-1-3 libxcb-xinerama0 libxcb-cursor0 libxcb-shape0 \
             libxcb-icccm4 libxcb-keysyms1 libxcb-render-util0 libxcb-image0 \
-            libnss3 libasound2 libfuse2 execstack
+            libnss3 libasound2 libfuse2 execstack \
+            libportaudio2 portaudio19-dev
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Setup Python environment
         run: |
-          uv python install 3.12
-          uv venv --python 3.12 .venv
+          uv python install 3.13
+          uv venv --python 3.13 .venv
           uv sync
 
       - name: Determine version
@@ -130,8 +130,8 @@ jobs:
 
       - name: Setup Python environment
         run: |
-          uv python install 3.12
-          uv venv --python 3.12 .venv
+          uv python install 3.13
+          uv venv --python 3.13 .venv
           uv sync
 
       - name: Determine version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,7 @@ jobs:
             libgl1-mesa-dev libegl1-mesa-dev libxkbcommon0 libfontconfig1 \
             libdbus-1-3 libxcb-xinerama0 libxcb-cursor0 libxcb-shape0 \
             libxcb-icccm4 libxcb-keysyms1 libxcb-render-util0 libxcb-image0 \
-            libnss3 libasound2 libfuse2 execstack \
-            libportaudio2 portaudio19-dev
+            libnss3 libasound2 libfuse2 execstack
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -77,6 +76,13 @@ jobs:
 
       - name: Build application
         run: pnpm run build
+
+      - name: Remove bundled PortAudio
+        run: |
+          # Remove bundled PortAudio so the app uses the system's libportaudio
+          # which has PipeWire/PulseAudio backends. Ubuntu's PortAudio only has ALSA.
+          rm -f ./dist/VoiceFlow/_internal/libportaudio*
+          echo "Removed bundled PortAudio (will use system library at runtime)"
 
       - name: Clear executable stack flags
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,9 @@ jobs:
         run: |
           # python-build-standalone builds ship libpython with GNU_STACK RWE,
           # which Linux 6.8+ kernels reject. Clear the flag on all bundled .so files.
-          find ./dist/VoiceFlow -name '*.so*' -exec execstack -c {} +
+          find ./dist/VoiceFlow -type f -name '*.so*' -exec execstack -c {} +
           echo "Verifying no executable stacks remain..."
-          BAD=$(find ./dist/VoiceFlow -name '*.so*' -exec sh -c \
+          BAD=$(find ./dist/VoiceFlow -type f -name '*.so*' -exec sh -c \
             'readelf -l "$1" 2>/dev/null | grep -A1 GNU_STACK | grep -q RWE && echo "$1"' _ {} \;)
           if [ -n "$BAD" ]; then
             echo "::error::Files still have executable stack: $BAD"

--- a/installer/voiceflow.iss
+++ b/installer/voiceflow.iss
@@ -2,7 +2,7 @@
 ; Creates a Windows installer from the PyInstaller --onedir output
 
 #define MyAppName "VoiceFlow"
-#define MyAppVersion "1.3.2"
+#define MyAppVersion "1.4.0"
 #define MyAppPublisher "VoiceFlow"
 #define MyAppURL "https://github.com/your-repo/voiceflow"
 #define MyAppExeName "VoiceFlow.exe"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voiceflow",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "npm-run-all --parallel vite pyloid",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "VoiceFlow"
-version = "1.3.2"
+version = "1.4.0"
 readme = "README.md"
 description = "Voice-to-text paste utility"
 

--- a/src-pyloid/build/build.py
+++ b/src-pyloid/build/build.py
@@ -42,6 +42,9 @@ if __name__ == '__main__':
 		extra_args += [
 			'--collect-all=evdev',
 			'--hidden-import=evdev',
+			# Don't bundle PortAudio - use system's libportaudio which has
+			# PipeWire/PulseAudio backends. Ubuntu's PortAudio only has ALSA.
+			'--exclude-module=_sounddevice_data',
 		]
 
 	pyinstaller(

--- a/src-pyloid/services/audio.py
+++ b/src-pyloid/services/audio.py
@@ -9,7 +9,7 @@ log = get_logger("audio")
 
 
 class AudioService:
-    SAMPLE_RATE = 16000  # Whisper expects 16kHz
+    TARGET_SAMPLE_RATE = 16000  # Whisper expects 16kHz
     CHANNELS = 1  # Mono
     DTYPE = np.float32
 
@@ -20,6 +20,7 @@ class AudioService:
         self._stream: Optional[sd.InputStream] = None
         self._amplitude_callback: Optional[Callable[[float], None]] = None
         self._device_id: Optional[int] = None  # None = default device
+        self._actual_sample_rate: int = self.TARGET_SAMPLE_RATE
 
     def set_device(self, device_id: Optional[int]):
         """Set the input device to use. None for default."""
@@ -62,16 +63,34 @@ class AudioService:
                 break
 
         log.info("Starting recording", device_id=self._device_id)
-        self._stream = sd.InputStream(
-            samplerate=self.SAMPLE_RATE,
-            channels=self.CHANNELS,
-            dtype=self.DTYPE,
-            callback=self._audio_callback,
-            blocksize=1024,
-            device=self._device_id,
-        )
+
+        # Try 16kHz first (Whisper's native rate), fall back to device default
+        self._actual_sample_rate = self.TARGET_SAMPLE_RATE
+        try:
+            self._stream = sd.InputStream(
+                samplerate=self.TARGET_SAMPLE_RATE,
+                channels=self.CHANNELS,
+                dtype=self.DTYPE,
+                callback=self._audio_callback,
+                blocksize=1024,
+                device=self._device_id,
+            )
+        except sd.PortAudioError:
+            device_info = sd.query_devices(self._device_id, 'input')
+            fallback_rate = int(device_info['default_samplerate'])
+            log.warning("16kHz not supported, using device default",
+                        fallback_rate=fallback_rate)
+            self._actual_sample_rate = fallback_rate
+            self._stream = sd.InputStream(
+                samplerate=fallback_rate,
+                channels=self.CHANNELS,
+                dtype=self.DTYPE,
+                callback=self._audio_callback,
+                blocksize=1024,
+                device=self._device_id,
+            )
         self._stream.start()
-        log.debug("Recording started")
+        log.debug("Recording started", sample_rate=self._actual_sample_rate)
 
     def stop_recording(self) -> np.ndarray:
         if not self._recording:
@@ -98,6 +117,17 @@ class AudioService:
         # Concatenate all chunks
         audio = np.concatenate(self._audio_data)
         self._audio_data = []
+
+        # Resample to 16kHz if recorded at a different rate
+        if self._actual_sample_rate != self.TARGET_SAMPLE_RATE:
+            ratio = self.TARGET_SAMPLE_RATE / self._actual_sample_rate
+            new_length = int(len(audio) * ratio)
+            indices = np.linspace(0, len(audio) - 1, new_length)
+            audio = np.interp(indices, np.arange(len(audio)), audio).astype(self.DTYPE)
+            log.debug("Resampled audio",
+                      from_rate=self._actual_sample_rate,
+                      to_rate=self.TARGET_SAMPLE_RATE,
+                      samples=new_length)
 
         return audio
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,7 @@
 
 import { Lock, Gauge, Wand2 } from "lucide-react";
 
-export const APP_VERSION = "1.3.2";
+export const APP_VERSION = "1.4.0";
 
 export const THEME_OPTIONS = [
   { val: 'light', label: 'Light' },


### PR DESCRIPTION
## Summary

- Add GitHub Actions release workflow for automated Windows/Linux builds
- Linux builds on ubuntu-22.04 (glibc 2.35) fixing AppImage compatibility (#15)
- Clear executable stack flags on bundled .so files for kernel 6.8+ compat
- Add sample rate fallback in audio service — records at device native rate and resamples to 16kHz when hardware doesn't support it directly
- Don't bundle PortAudio — use system library with PipeWire/PulseAudio backends
- Track lockfiles (pnpm-lock.yaml, uv.lock) for reproducible CI builds
- Sync version across all 4 version files to 1.4.0

Fixes #15

## Test plan

- [x] CI workflow tested on dev via workflow_dispatch
- [x] Linux AppImage: no glibc error, no execstack error
- [x] Audio: all devices work via 48kHz fallback + resample
- [x] Windows: .exe installer builds successfully
- [x] Transcription verified: "Good to meet you, bye. Hello."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio recording stability by adding automatic fallback and resampling support for audio devices with non-standard sample rates.

* **Chores**
  * Released version 1.4.0.
  * Optimized system dependencies and build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->