### PR TITLE
release: v1.6.0-rc2 hotfix bundle

### DIFF
--- a/installer/voiceflow.iss
+++ b/installer/voiceflow.iss
@@ -2,7 +2,7 @@
 ; Creates a Windows installer from the PyInstaller --onedir output
 
 #define MyAppName "VoiceFlow"
-#define MyAppVersion "1.6.0-rc1"
+#define MyAppVersion "1.6.0-rc2"
 #define MyAppPublisher "infiniV"
 #define MyAppURL "https://get-voice-flow.vercel.app/"
 #define MyAppSupportURL "https://github.com/infiniV/VoiceFlow/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voiceflow",
   "private": true,
-  "version": "1.6.0-rc1",
+  "version": "1.6.0-rc2",
   "type": "module",
   "scripts": {
     "dev": "npm-run-all --parallel vite pyloid",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "VoiceFlow"
-version = "1.6.0rc1"
+version = "1.6.0rc2"
 readme = "README.md"
 description = "Offline voice-to-text dictation for Windows and Linux, using Whisper."
 keywords = ["voice-to-text", "dictation", "whisper", "speech-to-text", "offline", "linux", "wayland", "transcription", "stt", "faster-whisper", "privacy"]

--- a/src-pyloid/app_controller.py
+++ b/src-pyloid/app_controller.py
@@ -155,6 +155,18 @@ class AppController:
             return
         self._shutdown_done = True
         self.hotkey_service.stop()
+        # Stop any active meeting recording before tearing down. parec /
+        # sounddevice hold PipeWire / PortAudio handles that, if leaked, can
+        # corrupt the global audio routing graph (observed: Teams loses
+        # inbound audio after a VoiceFlow wedge + window close). Failure is
+        # tolerated — recover_unfinished() on the next startup will pick up
+        # any partial recording.
+        try:
+            if self.meetings.recorder.get_state()["state"] != "idle":
+                info("Shutdown: stopping active meeting recording")
+                self.meetings.stop()
+        except Exception as exc:
+            warning(f"Shutdown: failed to stop active meeting: {exc}")
         self.transcription_service.unload_model()
 
     def _handle_hotkey_activate(self):

--- a/src-pyloid/app_controller.py
+++ b/src-pyloid/app_controller.py
@@ -56,6 +56,11 @@ class AppController:
         self._model_loaded = False
         self._model_loading = False
 
+        # Shutdown is wired from both QApplication.aboutToQuit and the
+        # post-app.run() path in main.py; this guard makes a second call a
+        # no-op instead of double-stopping the hotkey listener.
+        self._shutdown_done = False
+
         # Popup enabled state (disabled during onboarding)
         self._popup_enabled = True
 
@@ -144,7 +149,11 @@ class AppController:
         self.db.clear_old_history(settings.retention)
 
     def shutdown(self):
-        """Clean shutdown."""
+        """Clean shutdown. Idempotent — wired from both QApplication.aboutToQuit
+        and main.py's post-app.run() path, so it can fire twice on a normal exit."""
+        if self._shutdown_done:
+            return
+        self._shutdown_done = True
         self.hotkey_service.stop()
         self.transcription_service.unload_model()
 

--- a/src-pyloid/main.py
+++ b/src-pyloid/main.py
@@ -278,6 +278,25 @@ print("[DEBUG] Pyloid app created", flush=True)
 # reloads on respawn. The tray "Quit" item remains the only true exit.
 QApplication.instance().setQuitOnLastWindowClosed(False)
 
+# Patch pyloid.Pyloid.get_window_by_id to bypass its cross-thread Qt
+# roundtrip. pyloid-rpc validates the window_id on EVERY RPC request
+# (rpc.py:518) by calling self.pyloid.get_window_by_id(request_id), which
+# uses execute_command() — that emits a Qt signal to the main thread and
+# runs a nested QEventLoop.exec() in the asyncio RPC thread, with NO
+# timeout, waiting for the Qt main thread to reply. If the Qt main thread
+# is even briefly busy (WebEngine IPC, queued window.invoke calls during
+# an active meeting recording, etc.), the asyncio thread wedges forever
+# and every subsequent RPC request stacks up in aiohttp's accept queue
+# (observed in the field: LISTEN 4 128 with the Stop button dead while
+# the writer thread + WebChannel kept ticking). The Qt-side handler is
+# literally just `self.app.windows_dict.get(window_id)` (pyloid.py:2117,
+# 597), so we can do it directly from the asyncio thread — dict.get() is
+# atomic under the GIL.
+import types as _types
+def _fast_get_window_by_id(self, window_id):
+    return self.app.windows_dict.get(window_id)
+app.get_window_by_id = _types.MethodType(_fast_get_window_by_id, app)
+
 # Install the voiceflow:// handler on the default profile. The scheme itself
 # was registered above (before QApplication). The handler must outlive every
 # request, so we hold a module-level reference — Qt holds a non-owning ref.

--- a/src-pyloid/main.py
+++ b/src-pyloid/main.py
@@ -171,7 +171,7 @@ if sys.platform.startswith('linux'):
     print(f"[DEBUG] QTWEBENGINE_CHROMIUM_FLAGS = {os.environ['QTWEBENGINE_CHROMIUM_FLAGS']}", flush=True)
 
 from PySide6.QtCore import QObject, Signal, Qt
-from PySide6.QtWidgets import QWidget
+from PySide6.QtWidgets import QApplication, QWidget
 
 from server import server, register_onboarding_complete_callback, register_data_reset_callback, register_window_actions, register_download_progress_callback, register_popup_visibility_callback
 from app_controller import get_controller
@@ -271,6 +271,12 @@ if not ensure_single_instance():
 print("[DEBUG] Creating Pyloid app...", flush=True)
 app = Pyloid(app_name="VoiceFlow", single_instance=True, server=server)
 print("[DEBUG] Pyloid app created", flush=True)
+
+# Tray-resident daemon: closing the dashboard window must NOT quit the app.
+# Qt's default is True, which combined with Qt WebEngine's built-in Ctrl+W
+# turns "close window" into "kill the daemon" — global hotkey dies, model
+# reloads on respawn. The tray "Quit" item remains the only true exit.
+QApplication.instance().setQuitOnLastWindowClosed(False)
 
 # Install the voiceflow:// handler on the default profile. The scheme itself
 # was registered above (before QApplication). The handler must outlive every
@@ -823,10 +829,25 @@ else:
     # Dev: Standard Frame
     window = app.create_window(title="VoiceFlow", dev_tools=False, frame=True, transparent=False)
     # try:
-    #     window._window.web_view.page().setBackgroundColor(QColor(0, 0, 0, 0)) 
+    #     window._window.web_view.page().setBackgroundColor(QColor(0, 0, 0, 0))
     # except Exception as e:
     #     error(f"Failed to set transparent background: {e}")
     window.load_url("http://localhost:5173")
+
+# Qt-level close (native title-bar X, Ctrl+W from Qt WebEngine) routes through
+# Pyloid's BrowserWindow.closeEvent, which removes the window from
+# app.windows_dict and unconditionally calls app.quit() once the dict is empty
+# (.venv/.../pyloid/browser_window.py:1115). That bypasses
+# setQuitOnLastWindowClosed(False) — confirmed in dev: with the popup hidden
+# by preference, Ctrl+W on the dashboard fires app.quit() and the daemon dies.
+# Override the QMainWindow's closeEvent so any Qt-level close just hides the
+# window — matching the frontend's close_main_window RPC path. Tray "Quit"
+# still calls app.quit() explicitly, so explicit exits are unaffected.
+def _hide_main_window_on_close(event):
+    event.ignore()
+    if window:
+        window.hide()
+window._window._window.closeEvent = _hide_main_window_on_close
 
 # Enforce Minimum Size Globally based on Screen Size
 try:
@@ -866,6 +887,13 @@ else:
     window.show()
     log.info("Showing onboarding window")
     # Don't initialize popup during onboarding
+
+# Tear down services BEFORE Qt destroys QApplication. CTranslate2's CUDA
+# worker threads need to be joined while libcuda is still loaded — running
+# this in aboutToQuit (Qt event loop still alive) avoids the SIGABRT race
+# against libcuda's own atexit handler. The post-app.run() call below stays
+# as a fallback for non-Qt exit paths; controller.shutdown() is idempotent.
+QApplication.instance().aboutToQuit.connect(controller.shutdown)
 
 print(f"[DEBUG] About to call app.run(), onboarding_complete={onboarding_complete}", flush=True)
 app.run()

--- a/src-pyloid/services/database.py
+++ b/src-pyloid/services/database.py
@@ -20,9 +20,16 @@ class DatabaseService:
         self._init_db()
 
     def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path)
+        # timeout=5.0 + busy_timeout=5000 means SQLite returns SQLITE_BUSY
+        # after 5s of lock contention instead of blocking the asyncio RPC
+        # thread indefinitely. RPC handlers like get_history / get_stats are
+        # `async def` but call sync sqlite synchronously — without a timeout,
+        # a long-held write lock from another connection could wedge the
+        # whole HTTP RPC server.
+        conn = sqlite3.connect(self.db_path, timeout=5.0)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA busy_timeout = 5000")
         return conn
 
     def _init_db(self):

--- a/src-pyloid/services/recording/audio_source.py
+++ b/src-pyloid/services/recording/audio_source.py
@@ -270,6 +270,17 @@ class ParecAudioSource:
             )
         self._callback = on_frames
         self._stopped = False
+        # NOTE: do not pass preexec_fn here. We previously used it to set
+        # PR_SET_PDEATHSIG so parec would die with the parent — but
+        # preexec_fn is documented as unsafe in a multithreaded process
+        # (subprocess docs: the child can deadlock before exec if it
+        # inherits a held lock from another thread). VoiceFlow has many
+        # threads (writer, hotkey, asyncio RPC, transcribe queue, etc.)
+        # and that deadlock fired in the field on Bluetooth source
+        # selection — wedged the entire asyncio loop and corrupted
+        # PipeWire routing. Rely instead on controller.shutdown() (wired
+        # to QApplication.aboutToQuit) to kill parec on every normal exit
+        # path. Orphan parec on SIGKILL is the accepted trade-off.
         self._proc = subprocess.Popen(
             [
                 "parec",

--- a/src-pyloid/tests/test_app_controller.py
+++ b/src-pyloid/tests/test_app_controller.py
@@ -33,6 +33,7 @@ def controller(temp_db):
     ctrl._on_transcription_complete = None
     ctrl._on_amplitude = None
     ctrl._on_error = None
+    ctrl._shutdown_done = False
 
     yield ctrl
 
@@ -144,4 +145,13 @@ class TestAppController:
 
         controller.shutdown()
 
+        assert controller.hotkey_service.is_running() == False
+
+    def test_shutdown_is_idempotent(self, controller):
+        """shutdown can be called twice — wired from both aboutToQuit and the
+        post-app.run() path in main.py."""
+        controller.hotkey_service.start()
+        controller.shutdown()
+        # Second call must not raise; service must still be stopped.
+        controller.shutdown()
         assert controller.hotkey_service.is_running() == False

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -54,14 +54,23 @@ export function HomePage() {
   }, []);
 
   // Sync recording state with backend (covers hotkey-driven starts).
+  // In-flight guard prevents request stacking when the RPC server slows
+  // (observed: during long meeting recordings the asyncio RPC thread became
+  // sluggish; without this guard, getRecordingState calls accumulated and
+  // saturated aiohttp's accept queue, wedging the whole HTTP server).
   useEffect(() => {
     let cancelled = false;
+    let inFlight = false;
     const tick = async () => {
+      if (inFlight) return;
+      inFlight = true;
       try {
         const state = await api.getRecordingState();
         if (!cancelled) setIsRecording(state.recording);
       } catch {
         // backend may not be ready yet
+      } finally {
+        inFlight = false;
       }
     };
     tick();

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,7 @@
 
 import { Lock, Gauge, Wand2 } from "lucide-react";
 
-export const APP_VERSION = "1.6.0-rc1";
+export const APP_VERSION = "1.6.0-rc2";
 
 export const THEME_OPTIONS = [
   { val: 'light', label: 'Light' },


### PR DESCRIPTION
## Summary
Hotfix bundle on top of v1.6.0-rc1, shipped as `v1.6.0-rc2` pre-release.

- `fix(shutdown)`: clean CUDA teardown + tray daemon survives window close
- `fix(meetings)`: keep asyncio RPC alive during long recordings
- `fix(rpc)`: bypass pyloid's cross-thread window-id validation roundtrip
- `chore`: bump version to `1.6.0-rc2` across `package.json`, `installer/voiceflow.iss`, `pyproject.toml`, `src/lib/constants.ts`

## Test plan
- [ ] CI builds Linux (`tar.gz` + `AppImage`) and Windows (`.exe`) installers on tag push
- [ ] Smoke-test AppImage on Hyprland: hotkey → record → transcribe → paste
- [ ] Smoke-test Windows installer: tray survives dashboard close, long recording (>5 min) still transcribes
- [ ] Verify CUDA shutdown is clean (no hang on exit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now remains in system tray when main window is closed; use the tray menu to exit.

* **Bug Fixes**
  * Fixed duplicate shutdown execution.
  * Prevented overlapping recording state requests for improved reliability.
  * Enhanced database connection stability with timeout handling.

* **Chores**
  * Bumped version to 1.6.0-rc2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/infiniV/VoiceFlow/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->