### PR TITLE
chore: release v1.6.1

### DIFF
--- a/installer/voiceflow.iss
+++ b/installer/voiceflow.iss
@@ -2,7 +2,7 @@
 ; Creates a Windows installer from the PyInstaller --onedir output
 
 #define MyAppName "VoiceFlow"
-#define MyAppVersion "1.6.0"
+#define MyAppVersion "1.6.1"
 #define MyAppPublisher "infiniV"
 #define MyAppURL "https://get-voice-flow.vercel.app/"
 #define MyAppSupportURL "https://github.com/infiniV/VoiceFlow/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voiceflow",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "dev": "npm-run-all --parallel vite pyloid",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "VoiceFlow"
-version = "1.6.0"
+version = "1.6.1"
 readme = "README.md"
 description = "Offline voice-to-text dictation for Windows and Linux, using Whisper."
 keywords = ["voice-to-text", "dictation", "whisper", "speech-to-text", "offline", "linux", "wayland", "transcription", "stt", "faster-whisper", "privacy"]

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,7 @@
 
 import { Lock, Gauge, Wand2 } from "lucide-react";
 
-export const APP_VERSION = "1.6.0";
+export const APP_VERSION = "1.6.1";
 
 export const THEME_OPTIONS = [
   { val: 'light', label: 'Light' },

--- a/uv.lock
+++ b/uv.lock
@@ -2338,7 +2338,7 @@ wheels = [
 
 [[package]]
 name = "voiceflow"
-version = "1.6.0"
+version = "1.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "evdev", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
Release v1.6.1.

Bumps version 1.6.0 → 1.6.1 across `package.json`, `pyproject.toml`, `installer/voiceflow.iss`, `src/lib/constants.ts`, and `uv.lock`.

### Included since v1.6.0
- **Per-model deletion + reset onboarding-redirect fix** (#26, PR #29) — delete individual downloaded Whisper models from the picker; clearing models no longer kicks you back to onboarding.

Merging this, then tagging `v1.6.1` triggers the build & draft-release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version number incremented to 1.6.1 across all build and deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->