### PR TITLE
fix(ci): tolerate CRLF in uv.lock version check

### DIFF
--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -40,9 +40,11 @@ const TARGETS = [
   },
   {
     // uv.lock: the virtual root package block. The version line directly
-    // follows `name = "voiceflow"`.
+    // follows `name = "voiceflow"`. The `\r?\n` tolerates CRLF checkouts —
+    // the Windows CI runner has core.autocrlf=true and no .gitattributes
+    // pins uv.lock to LF, so a bare `\n` fails to match there.
     file: "uv.lock",
-    re: /(name = "voiceflow"\nversion = ")([^"]+)(")/,
+    re: /(name = "voiceflow"\r?\nversion = ")([^"]+)(")/,
   },
 ];
 


### PR DESCRIPTION
## Problem

The `v1.6.2` release workflow failed on `build-windows` at *Verify version consistency*:

```
ERROR: version pattern not found in uv.lock
```

The Linux job passed the identical check. Root cause: `scripts/version.mjs` matches the uv.lock virtual-root block with a literal `\n`:

```js
re: /(name = "voiceflow"\nversion = ")([^"]+)(")/
```

The Windows CI runner checks out with `core.autocrlf=true` and there is no `.gitattributes` pinning `uv.lock` to LF, so the file lands with CRLF and `\n` never matches `\r\n`. This is the new version-drift guard added this cycle (didn't exist for the v1.6.1 release), so the regression only surfaced now.

## Fix

Make the separator CRLF-tolerant: `\n` → `\r?\n`. Verified the regex matches both LF and CRLF inputs, and the `bump` replacement preserves the captured separator so it stays correct on either platform.