### PR TITLE
fix: recover Windows hold hotkey and reliably inject paste

### DIFF
--- a/src-pyloid/services/clipboard.py
+++ b/src-pyloid/services/clipboard.py
@@ -106,8 +106,18 @@ class ClipboardService:
                 log.warning("Paste tool failed, falling back to pyautogui",
                             tool=self._paste_tool, error=str(e))
 
-        # Fallback: pyautogui (works via XWayland)
-        self._get_pyautogui().hotkey('ctrl', 'v')
+        if sys.platform == 'win32':
+            # pyautogui's key injection is unreliable in some Windows desktop
+            # sessions. The keyboard library uses the same low-level backend as
+            # our global hotkey listener and consistently reaches native/UWP
+            # text fields.
+            import keyboard
+            keyboard.send('ctrl+v')
+            return
+
+        # Fallback for X11 and other desktop sessions.
+        pyautogui = self._get_pyautogui()
+        pyautogui.hotkey('ctrl', 'v')
 
     def paste_at_cursor(self, text: str):
         """Copy text to clipboard and paste at current cursor position."""

--- a/src-pyloid/services/hotkey.py
+++ b/src-pyloid/services/hotkey.py
@@ -185,6 +185,7 @@ class HotkeyService:
         self._toggle_active = False
         self._running = False
         self._max_recording_timer: Optional[threading.Timer] = None
+        self._hold_watchdog_timer: Optional[threading.Timer] = None
 
         # Hotkey configuration (defaults)
         self._hold_hotkey: str = "ctrl+win"
@@ -262,6 +263,7 @@ class HotkeyService:
             return  # Already recording in some mode
 
         self._hold_active = True
+        self._start_hold_watchdog()
         log.info("Hold hotkey activated")
         if self._on_activate:
             self._on_activate()
@@ -271,6 +273,7 @@ class HotkeyService:
         if not self._hold_active:
             return
         self._hold_active = False
+        self._cancel_hold_watchdog()
         self._cancel_max_timer()
         log.info("Hold hotkey deactivated")
         if self._on_deactivate:
@@ -323,6 +326,37 @@ class HotkeyService:
             self._deactivate_hold()
         elif self._toggle_active:
             self._deactivate_toggle()
+
+    def _start_hold_watchdog(self):
+        """Recover when Windows or the keyboard hook drops a key-up event."""
+        if IS_LINUX:
+            return
+        self._cancel_hold_watchdog()
+        self._hold_watchdog_timer = threading.Timer(0.25, self._check_hold_watchdog)
+        self._hold_watchdog_timer.daemon = True
+        self._hold_watchdog_timer.start()
+
+    def _cancel_hold_watchdog(self):
+        if self._hold_watchdog_timer:
+            self._hold_watchdog_timer.cancel()
+            self._hold_watchdog_timer = None
+
+    def _check_hold_watchdog(self):
+        self._hold_watchdog_timer = None
+        if not self._hold_active:
+            return
+
+        try:
+            import keyboard
+            if not self._are_hold_keys_pressed_keyboard(keyboard):
+                log.warning("Hold hotkey release recovered by watchdog")
+                self._deactivate_hold()
+                return
+        except Exception as e:
+            log.warning("Hold hotkey watchdog check failed", error=str(e))
+
+        if self._hold_active:
+            self._start_hold_watchdog()
 
     # ========================================================================
     # Platform-specific hotkey registration
@@ -385,24 +419,39 @@ class HotkeyService:
 
     def _check_hold_release_keyboard(self, event):
         """Check if hold hotkey should be deactivated on key release (Windows)."""
-        import keyboard
         if not self._hold_active:
             return
 
-        keys = self._parse_hotkey_keys(self._hold_hotkey)
-        all_pressed = True
-        for key in keys:
-            if key == 'win':
-                if not (keyboard.is_pressed('win') or keyboard.is_pressed('windows')):
-                    all_pressed = False
-                    break
-            elif not keyboard.is_pressed(key):
-                all_pressed = False
-                break
-
-        if not all_pressed:
+        released_key = self._normalize_keyboard_event_key(event.name)
+        if released_key in set(self._parse_hotkey_keys(self._hold_hotkey)):
             log.debug("Hold key released", key=event.name)
             self._deactivate_hold()
+
+    @staticmethod
+    def _normalize_keyboard_event_key(key: str) -> str:
+        key = key.strip().lower()
+        if key in ('windows', 'left windows', 'right windows', 'left win', 'right win'):
+            return 'win'
+        if key in ('control', 'left ctrl', 'right ctrl'):
+            return 'ctrl'
+        if key in ('left alt', 'right alt', 'alt gr'):
+            return 'alt'
+        if key in ('left shift', 'right shift'):
+            return 'shift'
+        return key
+
+    def _are_hold_keys_pressed_keyboard(self, keyboard_module) -> bool:
+        aliases_by_key = {
+            'win': ('win', 'windows', 'left windows', 'right windows'),
+            'ctrl': ('ctrl', 'left ctrl', 'right ctrl'),
+            'alt': ('alt', 'left alt', 'right alt'),
+            'shift': ('shift', 'left shift', 'right shift'),
+        }
+        for key in self._parse_hotkey_keys(self._hold_hotkey):
+            aliases = aliases_by_key.get(key, (key,))
+            if not any(keyboard_module.is_pressed(alias) for alias in aliases):
+                return False
+        return True
 
     def _register_toggle_hotkey_keyboard(self):
         """Register toggle hotkey using keyboard library (Windows)."""
@@ -533,6 +582,7 @@ class HotkeyService:
     def stop(self):
         """Stop listening for hotkeys."""
         self._running = False
+        self._cancel_hold_watchdog()
         self._unregister_hotkeys()
         self._cancel_max_timer()
         self._hold_active = False

--- a/src-pyloid/tests/test_clipboard_windows.py
+++ b/src-pyloid/tests/test_clipboard_windows.py
@@ -1,0 +1,19 @@
+import sys
+
+from services.clipboard import ClipboardService
+
+
+def test_windows_paste_uses_keyboard_send(monkeypatch):
+    sent = []
+
+    class Keyboard:
+        @staticmethod
+        def send(keys):
+            sent.append(keys)
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "keyboard", Keyboard)
+
+    ClipboardService()._simulate_paste_keystroke()
+
+    assert sent == ["ctrl+v"]

--- a/src-pyloid/tests/test_hotkey.py
+++ b/src-pyloid/tests/test_hotkey.py
@@ -1,4 +1,5 @@
 import pytest
+from types import SimpleNamespace
 from services.hotkey import HotkeyService, normalize_hotkey, validate_hotkey, are_hotkeys_conflicting
 
 
@@ -123,6 +124,46 @@ class TestAreHotkeysConflicting:
 
 
 class TestHotkeyService:
+    def test_release_of_hold_key_deactivates_without_polling_keyboard_state(self):
+        service = HotkeyService()
+        deactivations = []
+        service.set_callbacks(lambda: None, lambda: deactivations.append(True))
+        service._hold_hotkey = "ctrl+win"
+        service._hold_active = True
+
+        service._check_hold_release_keyboard(SimpleNamespace(name="left windows"))
+
+        assert service._hold_active is False
+        assert deactivations == [True]
+
+    def test_unrelated_release_does_not_deactivate_hold(self):
+        service = HotkeyService()
+        service._hold_hotkey = "ctrl+win"
+        service._hold_active = True
+
+        service._check_hold_release_keyboard(SimpleNamespace(name="a"))
+
+        assert service._hold_active is True
+
+    def test_watchdog_detects_missing_hold_key(self, monkeypatch):
+        service = HotkeyService()
+        deactivations = []
+        service.set_callbacks(lambda: None, lambda: deactivations.append(True))
+        service._hold_hotkey = "ctrl+win"
+        service._hold_active = True
+        monkeypatch.setattr(service, "_start_hold_watchdog", lambda: None)
+
+        class Keyboard:
+            @staticmethod
+            def is_pressed(key):
+                return key in {"ctrl", "left ctrl", "right ctrl"}
+
+        monkeypatch.setitem(__import__("sys").modules, "keyboard", Keyboard)
+        service._check_hold_watchdog()
+
+        assert service._hold_active is False
+        assert deactivations == [True]
+
     def test_initial_state_not_running(self):
         """Hotkey service starts in non-running state."""
         service = HotkeyService()


### PR DESCRIPTION
## Summary

Fixes two Windows-specific failures in the push-to-talk flow:

- The modifier-only hold shortcut can become permanently stuck after a missed or misread key-up event. Once `_hold_active` remains `True`, every later activation is ignored until VoiceFlow is restarted.
- Transcription is copied to the clipboard, but the synthetic `Ctrl+V` sent through `pyautogui` may never reach the focused text field.

## Environment

- VoiceFlow: v1.6.2
- OS: Windows 10 Pro 22H2, build 19045, x64
- Hold shortcut: `Ctrl+Win`
- Python runtime used to verify the patch: 3.11.9
- GPU/model configuration: NVIDIA RTX 5070 Ti, CUDA float16, faster-whisper large-v3

## Reproduction

### Stuck hold shortcut

1. Configure hold-to-record as `Ctrl+Win`.
2. Dictate repeatedly, releasing either Ctrl or Win first.
3. Eventually VoiceFlow remains in the recording state or stops reacting to the shortcut.
4. The process stays alive, but no later hotkey activation is accepted until restart.

The log ends after `Hold hotkey activated` without a matching deactivation. Because `_on_hold_press()` ignores input while `_hold_active` is already true, the service cannot recover.

### Paste failure

1. Focus a native Windows text field, including Notepad.
2. Dictate and release the hold shortcut.
3. Transcription succeeds and the text is present in the clipboard.
4. Logs report `Paste command sent`, but the field remains unchanged; manual Ctrl+V works.

A controlled Notepad test confirmed that `pyautogui.hotkey('ctrl', 'v')` did not insert text in this desktop session, while `keyboard.send('ctrl+v')` inserted and saved the expected text.

## Changes

### Hold hotkey recovery

- Deactivate immediately when a release event belongs to any key in the active hold combination instead of polling the potentially stale global state with `keyboard.is_pressed()`.
- Normalize left/right Windows, Ctrl, Alt, and Shift event names before comparison.
- Add a 250 ms watchdog while hold mode is active. If Windows drops a release callback, it checks the physical combination and safely deactivates the session.
- Cancel the watchdog during normal deactivation and shutdown.

### Windows paste injection

- Use `keyboard.send('ctrl+v')` on Windows.
- Keep the existing `pyautogui` fallback for non-Windows desktop sessions.

The `keyboard` package is already a Windows dependency and is already used by the global hotkey service, so this adds no dependency.

## Verification

- `pytest src-pyloid/tests/test_hotkey.py src-pyloid/tests/test_clipboard_windows.py -v`
  - 33 passed
- Full backend suite excluding transcription hardware tests:
  - 331 passed, 12 skipped
  - One pre-existing Windows failure remains in `test_delete_removes_only_target_model`; it depends on HOME/cache path handling and is unrelated to this change.
- TypeScript typecheck passed.
- ESLint completed with existing warnings and no errors.
- Production Vite + PyInstaller build completed successfully.
- Manual Notepad integration test passed with the patched `ClipboardService`.
- Patched build loaded large-v3 with CUDA float16 and registered `Ctrl+Win` successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved clipboard paste functionality on Windows systems using optimized keystroke handling

* **New Features**
  * Added automatic recovery mechanism for hold-mode hotkeys to improve reliability

* **Tests**
  * Added Windows-specific clipboard operation tests
  * Expanded test coverage for hold-key behavior and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->